### PR TITLE
Support boolean conditions in DAG edges

### DIFF
--- a/dag2langgraph/converter.py
+++ b/dag2langgraph/converter.py
@@ -27,7 +27,11 @@ def _validate_edge(edge: Dict[str, Any], node_ids: Set[str]) -> None:
     _ensure_bool("target" in edge and isinstance(edge["target"], str) and edge["target"], INVALID_DAG_ERROR)
     _ensure_bool(edge["source"] in node_ids and edge["target"] in node_ids, INVALID_DAG_ERROR)
     if "condition" in edge:
-        _ensure_bool(edge["condition"] is None or isinstance(edge["condition"], str), INVALID_DAG_ERROR)
+        _ensure_bool(
+            edge["condition"] is None
+            or isinstance(edge["condition"], (str, bool)),
+            INVALID_DAG_ERROR,
+        )
 
 
 def _has_cycle_kahn(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> bool:
@@ -94,7 +98,11 @@ def map_edges(validated_edges: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for e in validated_edges:
         item: Dict[str, Any] = {"source": e["source"], "target": e["target"]}
         if "condition" in e and e["condition"] is not None:
-            item["condition"] = e["condition"]
+            cond = e["condition"]
+            if isinstance(cond, bool):
+                item["condition"] = "true" if cond else "false"
+            else:
+                item["condition"] = cond
         out.append(item)
     return out
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -37,6 +37,24 @@ def test_convert_success_structure():
     assert cond_edge["condition"] == "ok"
 
 
+def test_bool_condition_edges():
+    dag = {
+        "nodes": [
+            {"id": "start", "type": "function", "name": "StartFn"},
+            {"id": "yes", "type": "function", "name": "YesFn"},
+            {"id": "no", "type": "function", "name": "NoFn"},
+        ],
+        "edges": [
+            {"source": "start", "target": "yes", "condition": True},
+            {"source": "start", "target": "no", "condition": False},
+        ],
+        "entry_point": "start",
+    }
+    out = convert_dag_to_langgraph(dag)
+    conds = {e["condition"] for e in out["edges"]}
+    assert conds == {"true", "false"}
+
+
 def test_missing_entry_point_error():
     dag = load_example("missing_entry_point.json")
     with pytest.raises(DagValidationError) as exc:


### PR DESCRIPTION
## Summary
- allow boolean `condition` fields when validating edges
- serialize boolean conditions to "true"/"false" in LangGraph edges
- cover boolean edge conditions with unit test

## Testing
- `poetry install`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bc96305d48832186bfe3e845f7e8bf